### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Trash2, ExternalLink, PlusCircle, MinusCircle, Sun, Moon, SlidersHorizontal, Bell, Save, FolderOpen } from 'lucide-react';
+import DOMPurify from 'dompurify';
 import { Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -505,7 +506,7 @@ function App() {
                                       {store.inStock ? 'In Stock' : 'Out of Stock'}
                                     </button>
                                     <a
-                                      href={store.url}
+                                      href={DOMPurify.sanitize(store.url)}
                                       target="_blank"
                                       rel="noopener noreferrer"
                                       className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"


### PR DESCRIPTION
Potential fix for [https://github.com/ChemicalAttention706/sb1-av7vlgen/security/code-scanning/1](https://github.com/ChemicalAttention706/sb1-av7vlgen/security/code-scanning/1)

To fix the problem, we need to ensure that the `store.url` is properly sanitized before being used in the `href` attribute. One way to achieve this is by using a library like `DOMPurify` to sanitize the URL. This will help prevent any malicious scripts from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the `store.url` before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
